### PR TITLE
remove dialog polyfill

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,5 @@
 		"editor.defaultFormatter": "svelte.svelte-vscode"
 	},
 	/* TypeScript */
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "${workspaceFolder}/node_modules/typescript/lib",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,5 @@
 		"editor.defaultFormatter": "svelte.svelte-vscode"
 	},
 	/* TypeScript */
-	"typescript.tsdk": "${workspaceFolder}/node_modules/typescript/lib",
+	"typescript.tsdk": "${workspaceFolder}/node_modules/typescript/lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,13 @@
 			"name": "quantum-game-arena",
 			"version": "0.4.0",
 			"license": "MIT",
-			"dependencies": {
-				"dialog-polyfill": "^0.5.6"
-			},
 			"devDependencies": {
 				"@sveltejs/adapter-vercel": "^1.0.0-next.32",
 				"@sveltejs/kit": "^1.0.0-next.202",
 				"@types/jest": "^27.0.3",
 				"@typescript-eslint/eslint-plugin": "^5.7.0",
 				"@typescript-eslint/parser": "^5.7.0",
+				"@typescript/lib-dom": "npm:@types/web@^0.0.61",
 				"eslint": "^8.4.1",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-svelte3": "^3.2.1",
@@ -30,7 +28,7 @@
 				"ts-jest": "^27.1.1",
 				"ts-node": "^10.4.0",
 				"tslib": "^2.3.1",
-				"typescript": "~4.5.2"
+				"typescript": "~4.5.5"
 			},
 			"engines": {
 				"node": "14.x || 16.x",
@@ -1691,6 +1689,13 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript/lib-dom": {
+			"name": "@types/web",
+			"version": "0.0.61",
+			"resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.61.tgz",
+			"integrity": "sha512-lQ4M3OSh8eFj55fz1RJsLhCubET/7duOXoKcxVaUXYXyxikD9BA+WWrqAn5CjJxrc82b7zFY4OCVIeVdkPLaGg==",
+			"dev": true
+		},
 		"node_modules/abab": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -2428,11 +2433,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/dialog-polyfill": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
-			"integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w=="
 		},
 		"node_modules/diff": {
 			"version": "4.0.2",
@@ -6714,9 +6714,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -35,15 +35,13 @@
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
-	"dependencies": {
-		"dialog-polyfill": "^0.5.6"
-	},
 	"devDependencies": {
 		"@sveltejs/adapter-vercel": "^1.0.0-next.32",
 		"@sveltejs/kit": "^1.0.0-next.202",
 		"@types/jest": "^27.0.3",
 		"@typescript-eslint/eslint-plugin": "^5.7.0",
 		"@typescript-eslint/parser": "^5.7.0",
+		"@typescript/lib-dom": "npm:@types/web@^0.0.61",
 		"eslint": "^8.4.1",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-svelte3": "^3.2.1",
@@ -57,7 +55,7 @@
 		"ts-jest": "^27.1.1",
 		"ts-node": "^10.4.0",
 		"tslib": "^2.3.1",
-		"typescript": "~4.5.2"
+		"typescript": "~4.5.5"
 	},
 	"engines": {
 		"node": "14.x || 16.x",

--- a/src/lib/games/AppBanner.svelte
+++ b/src/lib/games/AppBanner.svelte
@@ -1,21 +1,17 @@
 <script context="module" lang="ts">
 	export const prerender = true;
-
-	let dialogElement: HTMLDialogElement;
-	export async function openModal(miliSec: number = 2400) {
-		dialogPolyfill.registerDialog(dialogElement);
-		dialogElement.showModal();
-		setTimeout(() => dialogElement.close(), miliSec);
-	}
 </script>
 
 <script lang="ts">
-	import dialogPolyfill from 'dialog-polyfill';
 	import { onMount } from 'svelte';
-	onMount(openModal);
+	let dialogElement: HTMLDialogElement;
+	onMount(() => {
+		dialogElement.showModal();
+		setTimeout(() => dialogElement.close(), 2400);
+	});
 </script>
 
-<dialog class="modal" bind:this={dialogElement} open={false}>
+<dialog class="modal" bind:this={dialogElement}>
 	<slot />
 </dialog>
 
@@ -26,10 +22,9 @@
 		border-radius: 0;
 		box-shadow: 0 0 1rem black;
 		background-color: transparent;
+		pointer-events: none;
 
-		&::backdrop {
-			background-color: rgba(0, 0, 10, 0.3);
-		}
+		&::backdrop,
 		& + .backdrop {
 			background-color: rgba(0, 0, 10, 0.3);
 		}
@@ -37,6 +32,10 @@
 		&[open] {
 			transition: cubic-bezier(0, 0, 1, 1);
 			animation: slide-in 2.5s;
+		}
+
+		&:not([open]) {
+			opacity: 0;
 		}
 	}
 


### PR DESCRIPTION
`<dialog>` element will be supported.

- [Safari 15.4](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/)
- [FireFox 98.0](https://www.mozilla.org/en-US/firefox/98.0/releasenotes/)