### PR TITLE
Refactor QuantumTTT offline

### DIFF
--- a/src/lib/games/quantum-tictactoe/GameBoardSquare/MarkQuantums.svelte
+++ b/src/lib/games/quantum-tictactoe/GameBoardSquare/MarkQuantums.svelte
@@ -66,6 +66,19 @@ function getTextColor(mark: MarkType) {
 	font-size: 24px;
 	font-weight: bold;
 	line-height: 32px;
+
+	@media screen and (max-width: 600px) {
+		width: calc(100% / 3 - 8px);
+		margin: 2px 4px;
+		text-align: center;
+		font-size: 21px;
+		line-height: 28px;
+	}
+
+	@media screen and (max-width: 400px) {
+		font-size: 18px;
+		line-height: 24px;
+	}
 }
 
 .white {

--- a/src/lib/games/quantum-tictactoe/GameInfo.svelte
+++ b/src/lib/games/quantum-tictactoe/GameInfo.svelte
@@ -107,7 +107,7 @@ export let onResetGameClick: () => void;
 }
 
 .game-info {
-	margin-left: 20px;
+	margin: 0 20px 0;
 	top: 0px;
 	width: 480px;
 	display: flex;
@@ -116,7 +116,9 @@ export let onResetGameClick: () => void;
 	align-items: stretch;
 
 	@media screen and (max-width: 600px) {
-		width: 95vw;
+		margin-left: auto;
+		margin-right: auto;
+		width: 90vw;
 	}
 }
 
@@ -188,7 +190,8 @@ export let onResetGameClick: () => void;
 	font-weight: bold;
 
 	@media screen and (max-width: 600px) {
-		width: 90vw;
+		padding-left: 4px;
+		padding-right: 4px;
 		font-size: 16px;
 	}
 }

--- a/src/lib/games/quantum-tictactoe/Graph.ts
+++ b/src/lib/games/quantum-tictactoe/Graph.ts
@@ -100,18 +100,16 @@ export default class Graph {
 
 		// case two: cycle of len 2
 		const start = this.getNode(startId);
-		const visited: Set<Node> = new Set();
 		const endToEdge: Map<Node, Edge> = new Map();
 
 		for (const edge of start.edges) {
-			if (visited.has(edge.end)) {
+			if (endToEdge.has(edge.end)) {
 				return [
 					[edge.start.id, edge.end.id],
-					[edge.key, endToEdge.get(edge.end)?.key as EdgeKeyType]
+					[edge.key, (endToEdge.get(edge.end) as Edge).key]
 				];
 			}
 
-			visited.add(edge.end);
 			endToEdge.set(edge.end, edge);
 		}
 

--- a/src/lib/games/quantum-tictactoe/QuantumTTT.ts
+++ b/src/lib/games/quantum-tictactoe/QuantumTTT.ts
@@ -133,22 +133,26 @@ export default class QuantumTTT {
 
 		// if cycle is not null, there is a cyclic entanglement.
 		const cycle = this.g.getCycle(i);
+		if (cycle) {
+			const msg =
+				'循環もつれが発生しました！' +
+				`プレイヤー${this.notWhoseTurn()}はマークを確定させるマスを選択してください。`;
+			this.setState({
+				qSquares,
+				cycleSquares: cycle && (cycle[0] as MaxLengthArray<SquareType, 9>),
+				cycleMarks: cycle && (cycle[1] as MaxLengthArray<MarkType, 9>),
+				lastMove: i
+			});
+			return `${msg}`;
+		}
+
 		this.setState({
 			qSquares,
-			cycleSquares: cycle && (cycle[0] as MaxLengthArray<SquareType, 9>),
-			cycleMarks: cycle && (cycle[1] as MaxLengthArray<MarkType, 9>),
 			currentTurn: (this.state.currentTurn +
 				Number(this.state.currentSubTurn === 3)) as TurnNumType,
 			currentSubTurn: ((this.state.currentSubTurn + 1) % 4) as SubTurnType,
 			lastMove: i
 		});
-
-		if (cycle) {
-			const msg =
-				'循環もつれが発生しました！' +
-				`プレイヤー${this.notWhoseTurn()}はマークを確定させるマスを選択してください。`;
-			return `${msg}`;
-		}
 
 		if (this.isSecondMove())
 			return '2個目の量子マークを置いてください。循環もつれが発生すると、マスにある量子マークのうち1つのマークがそのマスの確定マークになります。';
@@ -178,7 +182,10 @@ export default class QuantumTTT {
 			this.setState({
 				cycleSquares: null,
 				cycleMarks: null,
-				collapseSquare: null
+				collapseSquare: null,
+				currentTurn: (this.state.currentTurn +
+					Number(this.state.currentSubTurn === 3)) as TurnNumType,
+				currentSubTurn: ((this.state.currentSubTurn + 1) % 4) as SubTurnType
 			});
 
 			return `プレイヤー${this.whoseTurn()}のターンです。`;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+import TheHeader from '$lib/TheHeader/index.svelte';
 import '../global.css';
 </script>
 
+<TheHeader />
 <slot />
 
 <style lang="scss">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import TheHeader from '$lib/TheHeader/index.svelte';
 import TheFooter from '$lib/TheFooter/index.svelte';
 
 import LogoTitleRowWhite from '$lib/assets/logo-title_row-white.svg.svelte';
@@ -20,7 +19,6 @@ let footerHeight: number;
 	<meta property="og:title" content="Quantum Game Arena" />
 </svelte:head>
 
-<TheHeader />
 <article style="padding-bottom: {footerHeight}px;">
 	<header class="hero" id="top">
 		<img src={heroImage} alt="" />

--- a/src/routes/games/quantum-tictactoe/+page.svelte
+++ b/src/routes/games/quantum-tictactoe/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import TheHeader from '$lib/TheHeader/index.svelte';
 import TheFooter from '$lib/TheFooter/index.svelte';
 
 let footerHeight: number;
@@ -12,7 +11,6 @@ let footerHeight: number;
 	<meta property="og:title" content="Quantum Tic-Tac-Toe - Quantum Game Arena" />
 </svelte:head>
 
-<TheHeader />
 <main class="main" style="padding-bottom:{footerHeight}px">
 	<h1 class="main--title">Quantum Tic-Tac-Toe</h1>
 	<ul class="nav">

--- a/src/routes/games/quantum-tictactoe/play/[roomId]/+page.svelte
+++ b/src/routes/games/quantum-tictactoe/play/[roomId]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import TheHeader from '$lib/TheHeader/index.svelte';
 // import OnlineApp from '$lib/games/quantum-tictactoe/OnlineApp.svelte';
 import OnlineApp from '$lib/games/quantum-tictactoe/OfflineApp.svelte';
 </script>
@@ -11,7 +10,6 @@ import OnlineApp from '$lib/games/quantum-tictactoe/OfflineApp.svelte';
 	<meta property="og:title" content="Quantum Tic-Tac-Toe - Quantum Game Arena" />
 </svelte:head>
 
-<TheHeader />
 <main class="main">
 	<!-- <SvelteDipper /> -->
 	<h1 class="title">Quantum Tic-Tac-Toe</h1>

--- a/src/routes/games/quantum-tictactoe/play/human/+page.svelte
+++ b/src/routes/games/quantum-tictactoe/play/human/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import TheHeader from '$lib/TheHeader/index.svelte';
 import OfflineApp from '$lib/games/quantum-tictactoe/OfflineApp.svelte';
 </script>
 
@@ -10,7 +9,6 @@ import OfflineApp from '$lib/games/quantum-tictactoe/OfflineApp.svelte';
 	<meta property="og:title" content="Quantum Tic-Tac-Toe - Quantum Game Arena" />
 </svelte:head>
 
-<TheHeader />
 <main class="main">
 	<!-- <SvelteDipper /> -->
 	<h1 class="title">Quantum Tic-Tac-Toe</h1>
@@ -21,7 +19,8 @@ import OfflineApp from '$lib/games/quantum-tictactoe/OfflineApp.svelte';
 .main {
 	width: 100%;
 	height: 100%;
-	margin-top: var(--header-height);
+	min-height: calc(100svh - var(--header-height));
+	padding-top: var(--header-height);
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/routes/games/quantum-tictactoe/tutorial/+page.svelte
+++ b/src/routes/games/quantum-tictactoe/tutorial/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import TheHeader from '$lib/TheHeader/index.svelte';
 import TheFooter from '$lib/TheFooter/index.svelte';
 
 import t1Image from '$lib/assets/tutorial1.png';
@@ -21,7 +20,6 @@ let footerHeight: number;
 	<meta property="og:title" content="Quantum TTT Tutorial - Quantum Game Arena" />
 </svelte:head>
 
-<TheHeader />
 <main class="main" style="padding-bottom:{footerHeight}px">
 	<h1 class="title">Quantum Tic-Tac-Toe Tutorial</h1>
 

--- a/src/routes/games/quantum-tictactoe/tutorial/+page.svelte
+++ b/src/routes/games/quantum-tictactoe/tutorial/+page.svelte
@@ -95,7 +95,7 @@ let footerHeight: number;
 					>のです。
 					<br />
 					循環エンタングルメントを発生させたプレイヤー<em class="ja-jp">ではない</em>プレイヤー（X
-					をマークしたことで発生した場合は
+					がマークしたことで発生した場合は
 					Y）が、量子マークを２つの古典状態のうちのどちらにするか決定します。
 				</p>
 				<img src={t6Image} alt="collapse の選択中の盤面" height="200px" />


### PR DESCRIPTION
Fixes #86 

- expand contents to fill viewport on mobiles
- fix: quantum marks overflow on mobile; for #86 

<img width="387" alt="スクリーンショット 2022-12-31 23 18 39" src="https://user-images.githubusercontent.com/26079835/210140296-e550294b-d5e4-42f9-b9c3-cef792abc625.png">
