### PR TITLE
Fix CI error & Update dependencies

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -58,6 +58,7 @@ module.exports = {
 		'@typescript-eslint/no-confusing-non-null-assertion': 'warn',
 		'@typescript-eslint/no-duplicate-imports': 'error',
 		'@typescript-eslint/no-implicit-any-catch': 'error',
+		'@typescript-eslint/no-import-type-side-effects': 'error',
 		'@typescript-eslint/no-require-imports': 'error',
 		'@typescript-eslint/unbound-method': 'off'
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
 				"@vercel/analytics": "^1.0.1"
 			},
 			"devDependencies": {
-				"@sveltejs/adapter-vercel": "^2.4.2",
-				"@sveltejs/kit": "^1.15.7",
+				"@sveltejs/adapter-vercel": "^3.0.0",
+				"@sveltejs/kit": "^1.20.0",
 				"@typescript-eslint/eslint-plugin": "^5.59.0",
 				"@typescript-eslint/parser": "^5.59.0",
 				"@typescript/lib-dom": "npm:@types/web@^0.0.99",
@@ -26,7 +26,7 @@
 				"prettier": "^2.8.7",
 				"prettier-plugin-svelte": "^2.10.0",
 				"sass": "^1.57.1",
-				"svelte": "^3.58.0",
+				"svelte": "^3.59.1",
 				"svelte-check": "~3.1.4",
 				"svelte-scrollto": "^0.2.0",
 				"tslib": "^2.5.0",
@@ -72,9 +72,9 @@
 			"dev": true
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
-			"integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
 			"cpu": [
 				"arm"
 			],
@@ -88,9 +88,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
-			"integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
 			"cpu": [
 				"arm64"
 			],
@@ -104,9 +104,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
-			"integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
 			"cpu": [
 				"x64"
 			],
@@ -120,9 +120,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
-			"integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
 			"cpu": [
 				"arm64"
 			],
@@ -136,9 +136,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
-			"integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
 			"cpu": [
 				"x64"
 			],
@@ -152,9 +152,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-			"integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -168,9 +168,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
-			"integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
 			"cpu": [
 				"x64"
 			],
@@ -184,9 +184,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
-			"integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
 			"cpu": [
 				"arm"
 			],
@@ -200,9 +200,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
-			"integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
 			"cpu": [
 				"arm64"
 			],
@@ -216,9 +216,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
-			"integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -232,9 +232,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
-			"integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -248,9 +248,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
-			"integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
 			"cpu": [
 				"mips64el"
 			],
@@ -264,9 +264,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
-			"integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -280,9 +280,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
-			"integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -296,9 +296,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
-			"integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
 			"cpu": [
 				"s390x"
 			],
@@ -312,9 +312,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
-			"integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
 			"cpu": [
 				"x64"
 			],
@@ -328,9 +328,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
-			"integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
 			"cpu": [
 				"x64"
 			],
@@ -344,9 +344,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
-			"integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
 			"cpu": [
 				"x64"
 			],
@@ -360,9 +360,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
-			"integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
 			"cpu": [
 				"x64"
 			],
@@ -376,9 +376,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
-			"integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
 			"cpu": [
 				"arm64"
 			],
@@ -392,9 +392,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
-			"integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
 			"cpu": [
 				"ia32"
 			],
@@ -408,9 +408,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
-			"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
 			"cpu": [
 				"x64"
 			],
@@ -621,38 +621,38 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-vercel": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-2.4.2.tgz",
-			"integrity": "sha512-HxItPKrt9DmSbKw2X4XVRYa4J2ueTEfQr79ijDcI/ZUtQ64d4X3ilUnLpmm1nXMBb1DyxaWJF4o8avwiV4O2Hw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-3.0.0.tgz",
+			"integrity": "sha512-XHbgdYtEDM70tRAN3AV5mQAis/9yLka7mLEWjzuhMwo377U1jfwxBzq2YYZdL4OF3rQnegR3yf92fTWnkEILPQ==",
 			"dev": true,
 			"dependencies": {
-				"@vercel/nft": "^0.22.1",
-				"esbuild": "^0.16.3"
+				"@vercel/nft": "^0.22.6",
+				"esbuild": "^0.17.18"
 			},
 			"peerDependencies": {
 				"@sveltejs/kit": "^1.5.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.15.7",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.7.tgz",
-			"integrity": "sha512-dgdKExsMJ16X3q8tEcuDlv+QIWAlJcf7IqCU2HWV13nmtTzwSA2n4VtEx9Gy5OGhH0SUAGNIupmlf0TdFSMXbw==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.20.0.tgz",
+			"integrity": "sha512-2ZW14afgcCQBk3BN8+FWUUCIZg+TKeDFuOMUpDNllTa6sKZ+YQNpxhsrt9abaZohPGsGGOYmk5fzy8D8MHVNBw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^2.0.0",
+				"@sveltejs/vite-plugin-svelte": "^2.4.1",
 				"@types/cookie": "^0.5.1",
 				"cookie": "^0.5.0",
-				"devalue": "^4.3.0",
+				"devalue": "^4.3.1",
 				"esm-env": "^1.0.0",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.0",
 				"mime": "^3.0.0",
 				"sade": "^1.8.1",
-				"set-cookie-parser": "^2.5.1",
+				"set-cookie-parser": "^2.6.0",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.20.0"
+				"undici": "~5.22.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -661,7 +661,7 @@
 				"node": "^16.14 || >=18"
 			},
 			"peerDependencies": {
-				"svelte": "^3.54.0",
+				"svelte": "^3.54.0 || ^4.0.0-next.0",
 				"vite": "^4.0.0"
 			}
 		},
@@ -678,11 +678,12 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.4.tgz",
-			"integrity": "sha512-pjqhW00KwK2uzDGEr+yJBwut+D+4XfJO/+bHHdHzPRXn9+1Jeq5JcFHyrUiYaXgHtyhX0RsllCTm4ssAx4ZY7Q==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.4.1.tgz",
+			"integrity": "sha512-bNNKvoRY89ptY7udeBSCmTdCVwkjmMcZ0j/z9J5MuedT8jPjq0zrknAo/jF1sToAza4NVaAgR9AkZoD9oJJmnA==",
 			"dev": true,
 			"dependencies": {
+				"@sveltejs/vite-plugin-svelte-inspector": "^1.0.2",
 				"debug": "^4.3.4",
 				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
@@ -694,7 +695,24 @@
 				"node": "^14.18.0 || >= 16"
 			},
 			"peerDependencies": {
-				"svelte": "^3.54.0",
+				"svelte": "^3.54.0 || ^4.0.0-next.0",
+				"vite": "^4.0.0"
+			}
+		},
+		"node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.2.tgz",
+			"integrity": "sha512-Cy1dUMcYCnDVV/hPLXa43YZJ2jGKVW5rA0xuNL9dlmYhT0yoS1g7+FOFSRlgk0BXKk/Oc7grs+8BVA5Iz2fr8A==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^14.18.0 || >= 16"
+			},
+			"peerDependencies": {
+				"@sveltejs/vite-plugin-svelte": "^2.2.0",
+				"svelte": "^3.54.0 || ^4.0.0-next.0",
 				"vite": "^4.0.0"
 			}
 		},
@@ -1849,9 +1867,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.0.tgz",
-			"integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.2.tgz",
+			"integrity": "sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==",
 			"dev": true
 		},
 		"node_modules/dir-glob": {
@@ -1966,9 +1984,9 @@
 			"dev": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
-			"integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1978,28 +1996,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.16.17",
-				"@esbuild/android-arm64": "0.16.17",
-				"@esbuild/android-x64": "0.16.17",
-				"@esbuild/darwin-arm64": "0.16.17",
-				"@esbuild/darwin-x64": "0.16.17",
-				"@esbuild/freebsd-arm64": "0.16.17",
-				"@esbuild/freebsd-x64": "0.16.17",
-				"@esbuild/linux-arm": "0.16.17",
-				"@esbuild/linux-arm64": "0.16.17",
-				"@esbuild/linux-ia32": "0.16.17",
-				"@esbuild/linux-loong64": "0.16.17",
-				"@esbuild/linux-mips64el": "0.16.17",
-				"@esbuild/linux-ppc64": "0.16.17",
-				"@esbuild/linux-riscv64": "0.16.17",
-				"@esbuild/linux-s390x": "0.16.17",
-				"@esbuild/linux-x64": "0.16.17",
-				"@esbuild/netbsd-x64": "0.16.17",
-				"@esbuild/openbsd-x64": "0.16.17",
-				"@esbuild/sunos-x64": "0.16.17",
-				"@esbuild/win32-arm64": "0.16.17",
-				"@esbuild/win32-ia32": "0.16.17",
-				"@esbuild/win32-x64": "0.16.17"
+				"@esbuild/android-arm": "0.17.19",
+				"@esbuild/android-arm64": "0.17.19",
+				"@esbuild/android-x64": "0.17.19",
+				"@esbuild/darwin-arm64": "0.17.19",
+				"@esbuild/darwin-x64": "0.17.19",
+				"@esbuild/freebsd-arm64": "0.17.19",
+				"@esbuild/freebsd-x64": "0.17.19",
+				"@esbuild/linux-arm": "0.17.19",
+				"@esbuild/linux-arm64": "0.17.19",
+				"@esbuild/linux-ia32": "0.17.19",
+				"@esbuild/linux-loong64": "0.17.19",
+				"@esbuild/linux-mips64el": "0.17.19",
+				"@esbuild/linux-ppc64": "0.17.19",
+				"@esbuild/linux-riscv64": "0.17.19",
+				"@esbuild/linux-s390x": "0.17.19",
+				"@esbuild/linux-x64": "0.17.19",
+				"@esbuild/netbsd-x64": "0.17.19",
+				"@esbuild/openbsd-x64": "0.17.19",
+				"@esbuild/sunos-x64": "0.17.19",
+				"@esbuild/win32-arm64": "0.17.19",
+				"@esbuild/win32-ia32": "0.17.19",
+				"@esbuild/win32-x64": "0.17.19"
 			}
 		},
 		"node_modules/escalade": {
@@ -3350,9 +3368,9 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -3468,9 +3486,9 @@
 			"dev": true
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-			"integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+			"version": "2.6.11",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+			"integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
 			"dev": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
@@ -4413,9 +4431,9 @@
 			"dev": true
 		},
 		"node_modules/sirv": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.2.tgz",
-			"integrity": "sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+			"integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
 			"dev": true,
 			"dependencies": {
 				"@polka/url": "^1.0.0-next.20",
@@ -4671,9 +4689,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.58.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
-			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==",
+			"version": "3.59.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.1.tgz",
+			"integrity": "sha512-pKj8fEBmqf6mq3/NfrB9SLtcJcUvjYSWyePlfCqN9gujLB25RitWK8PvFzlwim6hD/We35KbPlRteuA6rnPGcQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
@@ -4715,15 +4733,15 @@
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
-			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.2.tgz",
+			"integrity": "sha512-q/bAruCvFLwvNbeE1x3n37TYFb3mTBJ6TrCq6p2CoFbSTNhDE9oAtEfpy+wmc9So8AG0Tja+X0/mJzX9tSfvIg==",
 			"dev": true,
 			"engines": {
 				"node": "^12.20 || ^14.13.1 || >= 16"
 			},
 			"peerDependencies": {
-				"svelte": ">=3.19.0"
+				"svelte": "^3.19.0 || ^4.0.0-next.0"
 			}
 		},
 		"node_modules/svelte-preprocess": {
@@ -4798,14 +4816,14 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "6.1.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-			"integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+			"version": "6.1.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+			"integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
 			"dev": true,
 			"dependencies": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
-				"minipass": "^4.0.0",
+				"minipass": "^5.0.0",
 				"minizlib": "^2.1.1",
 				"mkdirp": "^1.0.3",
 				"yallist": "^4.0.0"
@@ -5022,15 +5040,15 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"version": "5.22.1",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+			"integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=12.18"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/uri-js": {
@@ -5142,395 +5160,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.17.tgz",
-			"integrity": "sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz",
-			"integrity": "sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.17.tgz",
-			"integrity": "sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz",
-			"integrity": "sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz",
-			"integrity": "sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz",
-			"integrity": "sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz",
-			"integrity": "sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz",
-			"integrity": "sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz",
-			"integrity": "sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz",
-			"integrity": "sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz",
-			"integrity": "sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz",
-			"integrity": "sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz",
-			"integrity": "sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz",
-			"integrity": "sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz",
-			"integrity": "sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz",
-			"integrity": "sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz",
-			"integrity": "sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz",
-			"integrity": "sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz",
-			"integrity": "sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz",
-			"integrity": "sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz",
-			"integrity": "sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-x64": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz",
-			"integrity": "sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/esbuild": {
-			"version": "0.17.17",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.17.tgz",
-			"integrity": "sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.17",
-				"@esbuild/android-arm64": "0.17.17",
-				"@esbuild/android-x64": "0.17.17",
-				"@esbuild/darwin-arm64": "0.17.17",
-				"@esbuild/darwin-x64": "0.17.17",
-				"@esbuild/freebsd-arm64": "0.17.17",
-				"@esbuild/freebsd-x64": "0.17.17",
-				"@esbuild/linux-arm": "0.17.17",
-				"@esbuild/linux-arm64": "0.17.17",
-				"@esbuild/linux-ia32": "0.17.17",
-				"@esbuild/linux-loong64": "0.17.17",
-				"@esbuild/linux-mips64el": "0.17.17",
-				"@esbuild/linux-ppc64": "0.17.17",
-				"@esbuild/linux-riscv64": "0.17.17",
-				"@esbuild/linux-s390x": "0.17.17",
-				"@esbuild/linux-x64": "0.17.17",
-				"@esbuild/netbsd-x64": "0.17.17",
-				"@esbuild/openbsd-x64": "0.17.17",
-				"@esbuild/sunos-x64": "0.17.17",
-				"@esbuild/win32-arm64": "0.17.17",
-				"@esbuild/win32-ia32": "0.17.17",
-				"@esbuild/win32-x64": "0.17.17"
 			}
 		},
 		"node_modules/vitefu": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.59.0",
 				"@typescript-eslint/parser": "^5.59.0",
 				"@typescript/lib-dom": "npm:@types/web@^0.0.99",
-				"@vitest/coverage-c8": "0.30.1",
+				"@vitest/coverage-c8": "^0.31.4",
 				"better-typescript-lib": "^2.3.0",
 				"eslint": "^8.38.0",
 				"eslint-config-prettier": "^8.8.0",
@@ -32,13 +32,26 @@
 				"tslib": "^2.5.0",
 				"typescript": "~5.0.2",
 				"typescript-eslint-language-service": "^5.0.5",
-				"vite": "^4.2.2",
-				"vitest": "0.30.1",
+				"vite": "^4.3.9",
+				"vitest": "^0.31.4",
 				"vscode-emmet-helper": "npm:@vscode/emmet-helper@^2.8.6"
 			},
 			"engines": {
 				"node": "18.x",
 				"npm": ">=7.21.1"
+			}
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {
@@ -521,10 +534,33 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -729,9 +765,9 @@
 			}
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+			"integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
 			"dev": true
 		},
 		"node_modules/@types/chai-subset": {
@@ -1155,43 +1191,63 @@
 			}
 		},
 		"node_modules/@vitest/coverage-c8": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.30.1.tgz",
-			"integrity": "sha512-/Wa3dtSuckpdngAmiCwowaEXXgJkqPrtfvrs9HTB9QoEfNbZWPu4E4cjEn4lJZb4qcGf4fxFtUA2f9DnDNAzBA==",
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.31.4.tgz",
+			"integrity": "sha512-VPx368m4DTcpA/P0v3YdVxl4QOSh1DbUcXURLRvDShrIB5KxOgfzw4Bn2R8AhAe/GyiWW/FIsJ/OJdYXCCiC1w==",
 			"dev": true,
 			"dependencies": {
+				"@ampproject/remapping": "^2.2.1",
 				"c8": "^7.13.0",
+				"magic-string": "^0.30.0",
 				"picocolors": "^1.0.0",
 				"std-env": "^3.3.2"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/antfu"
+				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"vitest": ">=0.30.0 <1"
 			}
 		},
-		"node_modules/@vitest/expect": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.30.1.tgz",
-			"integrity": "sha512-c3kbEtN8XXJSeN81iDGq29bUzSjQhjES2WR3aColsS4lPGbivwLtas4DNUe0jD9gg/FYGIteqOenfU95EFituw==",
+		"node_modules/@vitest/coverage-c8/node_modules/magic-string": {
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "0.30.1",
-				"@vitest/utils": "0.30.1",
+				"@jridgewell/sourcemap-codec": "^1.4.13"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.4.tgz",
+			"integrity": "sha512-tibyx8o7GUyGHZGyPgzwiaPaLDQ9MMuCOrc03BYT0nryUuhLbL7NV2r/q98iv5STlwMgaKuFJkgBW/8iPKwlSg==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/spy": "0.31.4",
+				"@vitest/utils": "0.31.4",
 				"chai": "^4.3.7"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.30.1.tgz",
-			"integrity": "sha512-W62kT/8i0TF1UBCNMRtRMOBWJKRnNyv9RrjIgdUryEe0wNpGZvvwPDLuzYdxvgSckzjp54DSpv1xUbv4BQ0qVA==",
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.4.tgz",
+			"integrity": "sha512-Wgm6UER+gwq6zkyrm5/wbpXGF+g+UBB78asJlFkIOwyse0pz8lZoiC6SW5i4gPnls/zUcPLWS7Zog0LVepXnpg==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/utils": "0.30.1",
+				"@vitest/utils": "0.31.4",
 				"concordance": "^5.0.4",
 				"p-limit": "^4.0.0",
 				"pathe": "^1.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner/node_modules/p-limit": {
@@ -1222,14 +1278,17 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.30.1.tgz",
-			"integrity": "sha512-fJZqKrE99zo27uoZA/azgWyWbFvM1rw2APS05yB0JaLwUIg9aUtvvnBf4q7JWhEcAHmSwbrxKFgyBUga6tq9Tw==",
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.4.tgz",
+			"integrity": "sha512-LemvNumL3NdWSmfVAMpXILGyaXPkZbG5tyl6+RQSdcHnTj6hvA49UAI8jzez9oQyE/FWLKRSNqTGzsHuk89LRA==",
 			"dev": true,
 			"dependencies": {
 				"magic-string": "^0.30.0",
 				"pathe": "^1.1.0",
 				"pretty-format": "^27.5.1"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/snapshot/node_modules/magic-string": {
@@ -1245,23 +1304,29 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.30.1.tgz",
-			"integrity": "sha512-YfJeIf37GvTZe04ZKxzJfnNNuNSmTEGnla2OdL60C8od16f3zOfv9q9K0nNii0NfjDJRt/CVN/POuY5/zTS+BA==",
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.4.tgz",
+			"integrity": "sha512-3ei5ZH1s3aqbEyftPAzSuunGICRuhE+IXOmpURFdkm5ybUADk+viyQfejNk6q8M5QGX8/EVKw+QWMEP3DTJDag==",
 			"dev": true,
 			"dependencies": {
 				"tinyspy": "^2.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.30.1.tgz",
-			"integrity": "sha512-/c8Xv2zUVc+rnNt84QF0Y0zkfxnaGhp87K2dYJMLtLOIckPzuxLVzAtFCicGFdB4NeBHNzTRr1tNn7rCtQcWFA==",
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.4.tgz",
+			"integrity": "sha512-DobZbHacWznoGUfYU8XDPY78UubJxXfMNY1+SUdOp1NsI34eopSA6aZMeaGu10waSOeYwE8lxrd/pLfT0RMxjQ==",
 			"dev": true,
 			"dependencies": {
 				"concordance": "^5.0.4",
 				"loupe": "^2.3.6",
 				"pretty-format": "^27.5.1"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/abbrev": {
@@ -2263,9 +2328,9 @@
 			"dev": true
 		},
 		"node_modules/fast-diff": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true
 		},
 		"node_modules/fast-glob": {
@@ -3414,15 +3479,15 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
-			"integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+			"integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.2",
 				"pathe": "^1.1.0",
-				"pkg-types": "^1.0.2",
-				"ufo": "^1.1.1"
+				"pkg-types": "^1.0.3",
+				"ufo": "^1.1.2"
 			}
 		},
 		"node_modules/mri": {
@@ -3905,9 +3970,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-			"integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+			"integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
 			"dev": true
 		},
 		"node_modules/pathval": {
@@ -3959,20 +4024,20 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.2.tgz",
-			"integrity": "sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+			"integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
 			"dev": true,
 			"dependencies": {
 				"jsonc-parser": "^3.2.0",
-				"mlly": "^1.1.1",
+				"mlly": "^1.2.0",
 				"pathe": "^1.1.0"
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.22",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
-			"integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
+			"version": "8.4.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+			"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4222,9 +4287,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.20.6",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.6.tgz",
-			"integrity": "sha512-2yEB3nQXp/tBQDN0hJScJQheXdvU2wFhh6ld7K/aiZ1vYcak6N/BKjY1QrU6BvO2JWYS8bEs14FRaxXosxy2zw==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.0.tgz",
+			"integrity": "sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -4466,15 +4531,6 @@
 			},
 			"bin": {
 				"sorcery": "bin/sorcery"
-			}
-		},
-		"node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -4884,24 +4940,24 @@
 			}
 		},
 		"node_modules/tinybench": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.4.0.tgz",
-			"integrity": "sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
+			"integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
 			"dev": true
 		},
 		"node_modules/tinypool": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
-			"integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.5.0.tgz",
+			"integrity": "sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
-			"integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+			"integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
@@ -5019,9 +5075,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
-			"integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
+			"integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
 			"dev": true
 		},
 		"node_modules/unbox-primitive": {
@@ -5091,15 +5147,14 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.2.2.tgz",
-			"integrity": "sha512-PcNtT5HeDxb3QaSqFYkEum8f5sCVe0R3WK20qxgIvNBZPXU/Obxs/+ubBMeE7nLWeCo2LDzv+8hRYSlcaSehig==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+			"integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.17.5",
-				"postcss": "^8.4.21",
-				"resolve": "^1.22.1",
-				"rollup": "^3.18.0"
+				"postcss": "^8.4.23",
+				"rollup": "^3.21.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -5140,9 +5195,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.30.1.tgz",
-			"integrity": "sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==",
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.4.tgz",
+			"integrity": "sha512-uzL377GjJtTbuc5KQxVbDu2xfU/x0wVjUtXQR2ihS21q/NK6ROr4oG0rsSkBBddZUVCwzfx22in76/0ZZHXgkQ==",
 			"dev": true,
 			"dependencies": {
 				"cac": "^6.7.14",
@@ -5159,7 +5214,7 @@
 				"node": ">=v14.18.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/antfu"
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/vitefu": {
@@ -5177,19 +5232,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.30.1.tgz",
-			"integrity": "sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==",
+			"version": "0.31.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.4.tgz",
+			"integrity": "sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/chai": "^4.3.4",
+				"@types/chai": "^4.3.5",
 				"@types/chai-subset": "^1.3.3",
 				"@types/node": "*",
-				"@vitest/expect": "0.30.1",
-				"@vitest/runner": "0.30.1",
-				"@vitest/snapshot": "0.30.1",
-				"@vitest/spy": "0.30.1",
-				"@vitest/utils": "0.30.1",
+				"@vitest/expect": "0.31.4",
+				"@vitest/runner": "0.31.4",
+				"@vitest/snapshot": "0.31.4",
+				"@vitest/spy": "0.31.4",
+				"@vitest/utils": "0.31.4",
 				"acorn": "^8.8.2",
 				"acorn-walk": "^8.2.0",
 				"cac": "^6.7.14",
@@ -5200,13 +5255,12 @@
 				"magic-string": "^0.30.0",
 				"pathe": "^1.1.0",
 				"picocolors": "^1.0.0",
-				"source-map": "^0.6.1",
 				"std-env": "^3.3.2",
 				"strip-literal": "^1.0.1",
-				"tinybench": "^2.4.0",
-				"tinypool": "^0.4.0",
+				"tinybench": "^2.5.0",
+				"tinypool": "^0.5.0",
 				"vite": "^3.0.0 || ^4.0.0",
-				"vite-node": "0.30.1",
+				"vite-node": "0.31.4",
 				"why-is-node-running": "^2.2.2"
 			},
 			"bin": {
@@ -5216,7 +5270,7 @@
 				"node": ">=v14.18.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/antfu"
+				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.59.0",
 		"@typescript-eslint/parser": "^5.59.0",
 		"@typescript/lib-dom": "npm:@types/web@^0.0.99",
-		"@vitest/coverage-c8": "0.30.1",
+		"@vitest/coverage-c8": "^0.31.4",
 		"better-typescript-lib": "^2.3.0",
 		"eslint": "^8.38.0",
 		"eslint-config-prettier": "^8.8.0",
@@ -61,8 +61,8 @@
 		"tslib": "^2.5.0",
 		"typescript": "~5.0.2",
 		"typescript-eslint-language-service": "^5.0.5",
-		"vite": "^4.2.2",
-		"vitest": "0.30.1",
+		"vite": "^4.3.9",
+		"vitest": "^0.31.4",
 		"vscode-emmet-helper": "npm:@vscode/emmet-helper@^2.8.6"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
 		"lint": "eslint --fix --cache --cache-location ./node_modules/.cache/eslint/.eslintcache ."
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-vercel": "^2.4.2",
-		"@sveltejs/kit": "^1.15.7",
+		"@sveltejs/adapter-vercel": "^3.0.0",
+		"@sveltejs/kit": "^1.20.0",
 		"@typescript-eslint/eslint-plugin": "^5.59.0",
 		"@typescript-eslint/parser": "^5.59.0",
 		"@typescript/lib-dom": "npm:@types/web@^0.0.99",
@@ -55,7 +55,7 @@
 		"prettier": "^2.8.7",
 		"prettier-plugin-svelte": "^2.10.0",
 		"sass": "^1.57.1",
-		"svelte": "^3.58.0",
+		"svelte": "^3.59.1",
 		"svelte-check": "~3.1.4",
 		"svelte-scrollto": "^0.2.0",
 		"tslib": "^2.5.0",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,8 @@
-/// <reference types="@sveltejs/kit" />
+declare namespace App {
+	// interface Error {}
+	// interface Locals {}
+	// interface PageData {}
+	// interface Platform {}
+}
 
 declare module 'svelte-scrollto';

--- a/tsconfig.vitest-typecheck.json
+++ b/tsconfig.vitest-typecheck.json
@@ -1,0 +1,56 @@
+{
+	"compilerOptions": {
+		"paths": {
+			"$lib": ["./src/lib"],
+			"$lib/*": ["./src/lib/*"]
+		},
+		"rootDirs": [".", "./.svelte-kit/types"],
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"lib": ["esnext", "DOM", "DOM.Iterable"],
+		"moduleResolution": "node",
+		"module": "esnext",
+		"target": "esnext",
+
+		"sourceMap": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"allowJs": false,
+		"strict": true,
+
+		"allowUnreachableCode": true,
+		"allowUnusedLabels": true,
+		"exactOptionalPropertyTypes": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedIndexedAccess": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+
+		"downlevelIteration": true,
+		"importHelpers": true,
+
+		"newLine": "lf",
+		"noEmitHelpers": true,
+		"removeComments": true,
+
+		"types": ["vitest/importMeta"]
+	},
+	"include": [
+		"./.svelte-kit/ambient.d.ts",
+		"./.svelte-kit/types/**/$types.d.ts",
+		"./vite.config.ts",
+		"./src/**/*.ts",
+		"./src/**/*.svelte",
+		"./tests/**/*.ts",
+		"./tests/**/*.svelte"
+	],
+	"exclude": [
+		"./node_modules/**",
+		"./.svelte-kit/[!ambient.d.ts]**",
+		"./src/service-worker/index.ts"
+	]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,9 @@ export default defineConfig({
 			exclude: VITEST_COVERAGE_IGNORE_PATTERNS
 		},
 		typecheck: {
-			tsconfig: './tsconfig.eslint.json'
+			checker: 'tsc',
+			include: ['**/*{.,-}{test-d,spec-d}.{ts,svelte}'],
+			tsconfig: './tsconfig.vitest-typecheck.json'
 		}
 	},
 	define: {


### PR DESCRIPTION
Build Error
- update `@sveltejs/adapter-vercel` to the latest

Typecheck Error
- Both of `importNotUsedAsValues` and `preserveValueImports` options are deprecated and will stop functioning in TS 5.5.
- `verbatimModuleSyntax` option should be used instead.

Update dependencies
- update `@sveltejs/adapter-vercel` from v2.4 to v3.0
- update `@sveltejs/kit` from v1.15 to v1.20
- update `svelte` from 3.58 to 3.59
- update `vite` from 4.2 to v4.3
- update `vitest` to v0.31.4