### PR TITLE
テキストコンテンツのないボタンに `aria-label` 属性を追加する

### DIFF
--- a/src/lib/AppFooter.svelte
+++ b/src/lib/AppFooter.svelte
@@ -13,10 +13,18 @@ export let h: number;
 		</a>
 	</div>
 	<div class="footer__links">
-		<a href="https://twitter.com/QGameArena" class="twitter-button">
+		<a
+			href="https://twitter.com/QGameArena"
+			class="twitter-button"
+			aria-label="Twitter (X) account"
+		>
 			<TwitterLogoWhite styles="width: 1.25rem" />
 		</a>
-		<a href="https://github.com/u-sho/quantum-game-arena" class="github-button">
+		<a
+			href="https://github.com/u-sho/quantum-game-arena"
+			class="github-button"
+			aria-label="GitHub repository"
+		>
 			<GithubMarkWhite styles="width: 1.25rem; height: 1.25rem" />
 		</a>
 	</div>

--- a/src/lib/games/quantum-tictactoe/GameBoard.svelte
+++ b/src/lib/games/quantum-tictactoe/GameBoard.svelte
@@ -39,6 +39,15 @@ $: onClick = (row: 0 | 1 | 2, column: 0 | 1 | 2) => (): void => {
 };
 $: isHighlighted = (row: 0 | 1 | 2, column: 0 | 1 | 2): boolean =>
 	!!cycleSquares?.length && cycleSquares.includes((row * 3 + column) as SquareType);
+
+const currentSquareName = (
+	row: 0 | 1 | 2,
+	column: 0 | 1 | 2
+): `${'upper' | 'middle' | 'lower'} ${'left' | 'center' | 'right'} square` => {
+	const verticalPosition = row === 0 ? 'upper' : row === 1 ? 'middle' : 'lower';
+	const horizontalPosition = column === 0 ? 'left' : column === 1 ? 'center' : 'right';
+	return `${verticalPosition} ${horizontalPosition} square`;
+};
 </script>
 
 <div class="game-board">
@@ -52,6 +61,7 @@ $: isHighlighted = (row: 0 | 1 | 2, column: 0 | 1 | 2): boolean =>
 					isHighlighted={isHighlighted(row, column)}
 					isBeingCollapsed={collapseSquare === row * 3 + column}
 					onClick={onClick(row, column)}
+					squareName={currentSquareName(row, column)}
 				/>
 			{/each}
 		</div>

--- a/src/lib/games/quantum-tictactoe/GameBoardSquare.svelte
+++ b/src/lib/games/quantum-tictactoe/GameBoardSquare.svelte
@@ -30,15 +30,20 @@ export let isHighlighted: boolean;
 export let isBeingCollapsed: boolean;
 export let onClick: () => void;
 
+export let squareName: `${'upper' | 'middle' | 'lower'} ${'left' | 'center' | 'right'} square`;
+
 $: squareClass = cMark
 	? 'square'
 	: `square${isHighlighted ? ' highlighted' : ''}${isBeingCollapsed ? ' selected' : ''}`;
+
+$: ariaLabel = `${cMark ? `Classical ${cMark}` : qMarks.length > 0 ? `Quantum ${qMarks.join(', ')}` : ''} on ${squareName}`;
 </script>
 
 <div
 	class={squareClass}
 	on:click|preventDefault={onClick}
 	on:keypress|preventDefault={onClick}
+	aria-label={ariaLabel}
 	role="button"
 	tabindex="0"
 >


### PR DESCRIPTION
一応 lighthouse score の a11y 項目は満点になった．
![image](https://github.com/u-sho/quantum-game-arena/assets/26079835/26a7d5df-3d50-4663-af77-4b3459022ac6)
